### PR TITLE
Repair boundary grids and numerical symmetry

### DIFF
--- a/inst/include/kde1d/interpolation.hpp
+++ b/inst/include/kde1d/interpolation.hpp
@@ -93,7 +93,7 @@ InterpolationGrid::interpolate(const Eigen::VectorXd& x) const
     if (xev <= 0) {
       return values_(k) * std::exp(-0.5 * xev * xev);
     } else if (xev >= 1) {
-      return values_(k + 1) * std::exp(-0.5 * xev * xev);
+      return values_(k + 1) * std::exp(-0.5 * (xev - 1) * (xev - 1));
     }
 
     return cubic_poly(xev, find_cell_coefs(k));

--- a/inst/include/kde1d/kde1d.hpp
+++ b/inst/include/kde1d/kde1d.hpp
@@ -427,7 +427,12 @@ Kde1d::pdf_continuous(const Eigen::VectorXd& x) const
 {
   Eigen::VectorXd fhat = grid_.interpolate(x);
   auto trunc = [](const double& xx) { return std::max(xx, 0.0); };
-  return tools::unaryExpr_or_nan(fhat, trunc);
+  fhat = tools::unaryExpr_or_nan(fhat, trunc);
+  if (!std::isnan(xmin_))
+    fhat = (x.array() < xmin_).select(0.0, fhat);
+  if (!std::isnan(xmax_))
+    fhat = (x.array() > xmax_).select(0.0, fhat);
+  return fhat;
 }
 
 inline Eigen::VectorXd

--- a/inst/include/kde1d/kde1d.hpp
+++ b/inst/include/kde1d/kde1d.hpp
@@ -389,9 +389,11 @@ Kde1d::fit(const Eigen::VectorXd& x, const Eigen::VectorXd& weights)
   }
 
   // calculate effective degrees of freedom
-  interp::InterpolationGrid infl_grid(
-      grid_points, fitted.col(1).cwiseMin(3.0).cwiseMax(0), 0);
-  Eigen::VectorXd influences = infl_grid.interpolate(xx).array();
+  Eigen::VectorXd influences = fitted.col(1).cwiseMin(3.0).cwiseMax(0);
+  if (std::isnan(xmin_) && !std::isnan(xmax_))
+    influences.reverseInPlace();
+  interp::InterpolationGrid infl_grid(grid_points, influences, 0);
+  influences = infl_grid.interpolate(xx).array();
   edf_ = influences.sum() + static_cast<double>(prob0_ > 0);
 
   // store bandwidth in standardized format

--- a/inst/include/kde1d/kde1d.hpp
+++ b/inst/include/kde1d/kde1d.hpp
@@ -363,7 +363,7 @@ Kde1d::fit(const Eigen::VectorXd& x, const Eigen::VectorXd& weights)
   // correct estimated density for transformation
   Eigen::VectorXd values = boundary_correct(grid_points, fitted.col(0));
 
-  // move boundary points to xmin/xmax
+  // order grid points from left to right
   grid_points = finalize_grid(grid_points);
 
   // construct interpolation grid
@@ -822,25 +822,47 @@ Kde1d::construct_grid_points(const Eigen::VectorXd& x)
 {
   Eigen::VectorXd rng(2);
   rng << x.minCoeff(), x.maxCoeff();
-  if (std::isnan(xmin_) && std::isnan(xmax_)) {
+  if (type_ == VarType::discrete) {
+    // Discrete estimates use jittered observations without transformation.
+  } else if (std::isnan(xmin_) && std::isnan(xmax_)) {
     rng(0) -= 4 * bandwidth_;
+    rng(1) += 4 * bandwidth_;
+  } else if (!std::isnan(xmin_) && !std::isnan(xmax_)) {
+    Eigen::VectorXd boundaries(2);
+    boundaries << xmin_, xmax_;
+    rng = boundary_transform(boundaries);
+  } else {
+    rng(0) = boundary_transform(Eigen::VectorXd::Constant(
+      1, std::isnan(xmin_) ? xmax_ : xmin_))(0);
     rng(1) += 4 * bandwidth_;
   }
   auto zgrid = Eigen::VectorXd::LinSpaced(grid_size_ + 1, rng(0), rng(1));
-  return boundary_transform(zgrid, true);
+  Eigen::VectorXd grid_points = boundary_transform(zgrid, true);
+
+  // Avoid round-off at finite support boundaries before evaluating the fit.
+  if (type_ != VarType::discrete) {
+    if (!std::isnan(xmin_))
+      grid_points(0) = xmin_;
+    if (!std::isnan(xmax_))
+      grid_points(std::isnan(xmin_) ? 0 : grid_size_) = xmax_;
+  }
+
+  return grid_points;
 }
 
-//! moves the boundary points of the grid to xmin/xmax (if non-NaN).
+//! orders grid points from left to right.
 //! @param grid_points the grid points.
 inline Eigen::VectorXd
 Kde1d::finalize_grid(Eigen::VectorXd& grid_points)
 {
   if (std::isnan(xmin_) && !std::isnan(xmax_))
     grid_points.reverseInPlace();
-  if (!std::isnan(xmin_))
-    grid_points(0) = xmin_;
-  if (!std::isnan(xmax_))
-    grid_points(grid_points.size() - 1) = xmax_;
+  if (type_ == VarType::discrete) {
+    if (!std::isnan(xmin_))
+      grid_points(0) = xmin_;
+    if (!std::isnan(xmax_))
+      grid_points(grid_points.size() - 1) = xmax_;
+  }
 
   return grid_points;
 }

--- a/inst/include/kde1d/tools.hpp
+++ b/inst/include/kde1d/tools.hpp
@@ -118,6 +118,8 @@ linbin(const Eigen::VectorXd& x,
     if (li < num_bins) {
       gcnts(li) += (1 - rem) * weights(i);
       gcnts(li + 1) += rem * weights(i);
+    } else if (x(i) == upper) {
+      gcnts(num_bins) += weights(i);
     }
   }
 

--- a/tests/testthat/test_kde1d.R
+++ b/tests/testthat/test_kde1d.R
@@ -191,6 +191,19 @@ test_that("bounded fits are invariant under reflection", {
   expect_equal(fit$values, rev(reflected_fit$values))
 })
 
+test_that("one-boundary fits are invariant under reflection", {
+  set.seed(7)
+  observations <- rexp(500)
+  fit <- kde1d(observations, xmin = 0)
+  reflected_fit <- kde1d(-observations, xmax = 0)
+
+  expect_equal(fit$bw, reflected_fit$bw)
+  expect_equal(fit$grid_points, -rev(reflected_fit$grid_points))
+  expect_equal(fit$values, rev(reflected_fit$values))
+  expect_equal(fit$loglik, reflected_fit$loglik)
+  expect_equal(fit$edf, reflected_fit$edf)
+})
+
 test_that("boundary grids resolve the support beyond the observations", {
   set.seed(5)
 

--- a/tests/testthat/test_kde1d.R
+++ b/tests/testthat/test_kde1d.R
@@ -229,6 +229,14 @@ test_that("boundary grids resolve the support beyond the observations", {
   expect_gt(fit$grid_points[length(fit$grid_points) - 1], max(observations))
 })
 
+test_that("finite support truncates density without extrapolation", {
+  observations <- c(rep(0, 20), seq(0, 1, length.out = 200), rep(1, 20))
+  fit <- kde1d(observations, xmin = 0, xmax = 1, bw = 0.5)
+
+  expect_true(all(dkde1d(c(0, 1), fit) > 0))
+  expect_equal(dkde1d(c(-1e-8, 1 + 1e-8), fit), c(0, 0))
+})
+
 test_that("two-boundary fits are affine equivariant", {
   set.seed(6)
   observations <- rbeta(500, 2, 3)

--- a/tests/testthat/test_kde1d.R
+++ b/tests/testthat/test_kde1d.R
@@ -179,3 +179,14 @@ test_that("includes the point mass in zero-inflated log-likelihood", {
 
   expect_equal(fit$loglik, sum(log(dkde1d(observations, fit))))
 })
+
+test_that("bounded fits are invariant under reflection", {
+  set.seed(3)
+  observations <- runif(500)
+  fit <- kde1d(observations, xmin = 0, xmax = 1)
+  reflected_fit <- kde1d(1 - observations, xmin = 0, xmax = 1)
+
+  expect_equal(fit$bw, reflected_fit$bw)
+  expect_equal(fit$grid_points, 1 - rev(reflected_fit$grid_points))
+  expect_equal(fit$values, rev(reflected_fit$values))
+})

--- a/tests/testthat/test_kde1d.R
+++ b/tests/testthat/test_kde1d.R
@@ -190,3 +190,13 @@ test_that("bounded fits are invariant under reflection", {
   expect_equal(fit$grid_points, 1 - rev(reflected_fit$grid_points))
   expect_equal(fit$values, rev(reflected_fit$values))
 })
+
+test_that("density interpolation is continuous at the right grid endpoint", {
+  set.seed(4)
+  fit <- kde1d(rnorm(500))
+
+  expect_equal(
+    dkde1d(tail(fit$grid_points, 1), fit),
+    tail(fit$values, 1)
+  )
+})

--- a/tests/testthat/test_kde1d.R
+++ b/tests/testthat/test_kde1d.R
@@ -191,6 +191,42 @@ test_that("bounded fits are invariant under reflection", {
   expect_equal(fit$values, rev(reflected_fit$values))
 })
 
+test_that("boundary grids resolve the support beyond the observations", {
+  set.seed(5)
+
+  observations <- runif(500, 0.2, 0.8)
+  fit <- kde1d(observations, xmin = 0, xmax = 1, bw = 0.3)
+  expect_true(all(diff(fit$grid_points) > 0))
+  expect_equal(range(fit$grid_points), c(0, 1))
+  expect_lt(fit$grid_points[2], min(observations))
+  expect_gt(fit$grid_points[length(fit$grid_points) - 1], max(observations))
+
+  observations <- rexp(500)
+  fit <- kde1d(observations, xmin = 0, bw = 0.3)
+  expect_true(all(diff(fit$grid_points) > 0))
+  expect_equal(head(fit$grid_points, 1), 0)
+  expect_lt(fit$grid_points[2], min(observations))
+  expect_gt(tail(fit$grid_points, 1), max(observations))
+
+  observations <- -rexp(500)
+  fit <- kde1d(observations, xmax = 0, bw = 0.3)
+  expect_true(all(diff(fit$grid_points) > 0))
+  expect_equal(tail(fit$grid_points, 1), 0)
+  expect_lt(head(fit$grid_points, 1), min(observations))
+  expect_gt(fit$grid_points[length(fit$grid_points) - 1], max(observations))
+})
+
+test_that("two-boundary fits are affine equivariant", {
+  set.seed(6)
+  observations <- rbeta(500, 2, 3)
+  fit <- kde1d(observations, xmin = 0, xmax = 1)
+  scaled_fit <- kde1d(2 + 3 * observations, xmin = 2, xmax = 5)
+
+  expect_equal(scaled_fit$bw, fit$bw)
+  expect_equal(scaled_fit$grid_points, 2 + 3 * fit$grid_points)
+  expect_equal(scaled_fit$values, fit$values / 3)
+})
+
 test_that("density interpolation is continuous at the right grid endpoint", {
   set.seed(4)
   fit <- kde1d(rnorm(500))


### PR DESCRIPTION
## Stack

This PR is stacked on #64, which updates the bundled C++ backend and bumps the package to 1.1.2.

## Identified and fixed issues

### Upper-endpoint observations were dropped during linear binning

Observations equal to the upper grid limit mapped to `num_bins` and were rejected by the binning loop. They are now assigned to the last bin. This restores reflection equivariance in the FFT fit and plugin bandwidth selector.

### Right extrapolation was discontinuous at the grid endpoint

Right extrapolation used `exp(-xev^2 / 2)` although `xev = 1` at the right endpoint. It now uses the distance `xev - 1`, so evaluating the endpoint returns its stored value.

### Transformed grids did not resolve the declared support

For bounded fits, almost the entire interpolation grid covered only the observed sample range. After evaluating the fit, the endpoint coordinates were moved from the extreme observations to `xmin` and `xmax` without recomputing their values. A sample restricted to `[0.2, 0.8]` therefore represented each of `[0, 0.2]` and `[0.8, 1]` with one large, mismatched interval.

Finite boundaries now define the grid in transformed space before evaluation. Unbounded sides receive the same four-bandwidth transformed-space extension used by unbounded fits. Endpoint coordinates are made exact before their density values are calculated. The discrete jitter estimator retains its existing grid path.

### Right-boundary influence values were reversed relative to their grid

Right-boundary density values were returned to original-coordinate order, but influence values were not. A fit and its reflection had identical bandwidth, density, and log-likelihood while EDF changed from `8.11` to `604.22`. Influence values are now reversed together with the grid, restoring one-boundary reflection equivariance.

### PDF extrapolation leaked outside finite support

The interpolation layer extrapolates beyond its grid. For endpoint-heavy data on `[0, 1]`, this produced density near `2699` immediately outside both declared bounds. Continuous density evaluation now applies an exact support mask after interpolation while leaving values on and inside the support unchanged.

## Commits

Each repair is isolated:

1. `Preserve upper-endpoint mass in linear binning`
2. `Center right-tail interpolation at the grid endpoint`
3. `Resolve transformed grids across the support`
4. `Align right-boundary influence values`
5. `Truncate densities at finite support bounds`

## Validation

- 466 testthat assertions pass, including new grid-coverage, affine-equivariance, reflection-equivariance, endpoint-continuity, and support-truncation regressions
- source package builds successfully
- installation, examples, compiled-code checks, and tests pass under `R CMD check --as-cran --no-manual`
- the check retains only the pre-existing warning for `-Wno-ignored-attributes`; no new warnings or errors are introduced

Alternative transformations and reflection kernels are deliberately deferred until these deterministic defects can be benchmarked.
