### PR TITLE
Prepare kde1d 1.2.0 for CRAN

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         config:
           - {os: macOS-latest,   r: 'release'}
+          - {os: windows-latest, r: 'devel'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}

--- a/.github/workflows/revdepcheck.yaml
+++ b/.github/workflows/revdepcheck.yaml
@@ -3,13 +3,11 @@
 on:
   pull_request:
     branches: [main]
-  workflow_dispatch:
 
 name: revdepcheck
 
 jobs:
   R-CMD-check:
-    if: github.event_name == 'workflow_dispatch' || github.head_ref == 'dev'
     runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: kde1d
 Type: Package
 Title: Univariate Kernel Density Estimation
-Version: 1.1.2
+Version: 1.2.0
 Authors@R: c(
         person("Thomas", "Nagler",, "mail@tnagler.com", role = c("aut", "cre")),
         person("Thibault", "Vatter",, "thibault.vatter@gmail.com", role = c("aut"))
@@ -14,7 +14,6 @@ Description: Provides an efficient implementation of univariate local polynomial
     Nagler (2018b) <doi:10.48550/arXiv.1705.05431>.
 License: MIT + file LICENSE
 Encoding: UTF-8
-LazyData: true
 LinkingTo:
     BH,
     Rcpp,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,4 +31,4 @@ Suggests:
 URL: https://tnagler.github.io/kde1d/
 BugReports: https://github.com/tnagler/kde1d/issues/
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# kde1d 1.1.2
+# kde1d 1.2.0
 
 DEPENDENCIES
 

--- a/R/jitter.R
+++ b/R/jitter.R
@@ -9,7 +9,7 @@
 #' random and the noise may deteriorate the estimate by chance.
 #'
 #' Here, we add a form of deterministic noise that makes estimators well
-#' behaved. Tied occurences of a factor level are spread out uniformly
+#' behaved. Tied occurrences of a factor level are spread out uniformly
 #' (i.e., equidistantly) on the interval \eqn{[-0.5, 0.5]}. This is similar to
 #' adding random noise that is uniformly distributed, conditional on the
 #' observed outcome. Integrating over the outcome, one can check that the

--- a/man/dkde1d.Rd
+++ b/man/dkde1d.Rd
@@ -30,7 +30,7 @@ rkde1d(n, obj, quasi = FALSE)
 
 \item{quasi}{logical; the default (\code{FALSE}) returns pseudo-random
 numbers, use \code{TRUE} for quasi-random numbers (generalized Halton, see
-\code{\link[randtoolbox:quasiRNG]{randtoolbox::sobol()}}).}
+\code{\link[randtoolbox:sobol]{randtoolbox::sobol()}}).}
 }
 \value{
 The density, distribution function or quantile functions estimates

--- a/man/equi_jitter.Rd
+++ b/man/equi_jitter.Rd
@@ -20,7 +20,7 @@ continuous case (see, Nagler, 2018a/b). The drawback is that estimates are
 random and the noise may deteriorate the estimate by chance.
 
 Here, we add a form of deterministic noise that makes estimators well
-behaved. Tied occurences of a factor level are spread out uniformly
+behaved. Tied occurrences of a factor level are spread out uniformly
 (i.e., equidistantly) on the interval \eqn{[-0.5, 0.5]}. This is similar to
 adding random noise that is uniformly distributed, conditional on the
 observed outcome. Integrating over the outcome, one can check that the

--- a/man/kde1d-package.Rd
+++ b/man/kde1d-package.Rd
@@ -42,6 +42,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Thomas Nagler \email{mail@tnagler.com}
   \item Thibault Vatter \email{thibault.vatter@gmail.com}
 }
 


### PR DESCRIPTION
## Summary

- prepare the frontend as version 1.2.0 with the backend pinned at kde1d-cpp v1.2.0
- refresh generated package documentation with roxygen2 8.0.0
- add Windows-devel package checks
- run reverse-dependency checks only for pull requests targeting main

## Local validation

- clean recursive-clone source build
- R CMD check --as-cran: OK
- valgrind package check: OK, zero errors and zero lost bytes
- all package URLs valid
- source archive contains the backend public headers and license, with development artifacts excluded

The pull request CI will run the full platform and reverse-dependency matrices.
